### PR TITLE
* Release.bat fails with "unresolved externals" #1

### DIFF
--- a/DriveFusion/FusionGDShell.vcxproj
+++ b/DriveFusion/FusionGDShell.vcxproj
@@ -234,6 +234,7 @@ $(SolutionDir)/obj/$(Configuration)/bin/ProjectConfigGenerator.exe $(SolutionDir
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <RegisterOutput>false</RegisterOutput>
+      <AdditionalDependencies>Propsys.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>$(SolutionDir)/obj/$(Configuration)/bin/ProjectConfigGenerator.exe $(SolutionDir)/ProjectConfig.txt $(SolutionDir)/obj/$(Configuration)/gen/Config.h


### PR DESCRIPTION
Matched the linker inputs in the Release x86 target to the linker inputs in the working targets.
