### PR TITLE
Save As dialog no longer asks to overwrite new files

### DIFF
--- a/DriveFusion/ErrorSignaling.h
+++ b/DriveFusion/ErrorSignaling.h
@@ -27,14 +27,14 @@ limitations under the License.
       } \
     } while (false)
 
-#define CHECK_HR(function) \
+#define CHECK_HR(hresult) \
     do \
     { \
-      hr = function; \
+      hr = hresult; \
       if (!SUCCEEDED(hr)) \
       { \
         Log::WriteOutput( \
-            LogType::Error, L"\t" L#function L" failed with hr = %x", hr); \
+            LogType::Error, L"\t" L#hresult L" failed, hr = %x", hr); \
         return hr; \
       } \
     } while (false)
@@ -46,7 +46,8 @@ limitations under the License.
       { \
         hr = hrFail; \
         Log::WriteOutput( \
-            LogType::Error, L"\t" L#condition L" failed, " L#hrFail L" set"); \
+            LogType::Error, \
+            L"\t" L#condition L" failed, " L#hrFail L" = %x", hr); \
         return hr; \
       } \
     } while (false)

--- a/DriveFusion/ErrorSignaling.h
+++ b/DriveFusion/ErrorSignaling.h
@@ -1,0 +1,52 @@
+/*
+Copyright 2015 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#pragma once
+
+#define CHECK_ARG(condition) \
+    do \
+    { \
+      if (!(condition)) \
+      { \
+        hr = E_INVALIDARG; \
+        Log::WriteOutput( \
+            LogType::Error, L"\tArgument failed condition " L#condition); \
+        return hr; \
+      } \
+    } while (false)
+
+#define CHECK_HR(function) \
+    do \
+    { \
+      hr = function; \
+      if (!SUCCEEDED(hr)) \
+      { \
+        Log::WriteOutput( \
+            LogType::Error, L"\t" L#function L" failed with hr = %x", hr); \
+        return hr; \
+      } \
+    } while (false)
+
+#define CHECK_TRUE(condition, hrFail) \
+    do \
+    { \
+      if (!(condition)) \
+      { \
+        hr = hrFail; \
+        Log::WriteOutput( \
+            LogType::Error, L"\t" L#condition L" failed, " L#hrFail L" set"); \
+        return hr; \
+      } \
+    } while (false)

--- a/DriveFusion/FileManager.cpp
+++ b/DriveFusion/FileManager.cpp
@@ -154,7 +154,6 @@ const AboutInfo* FileManager::GetAbout()
 
 FileInfo* FileManager::GetFile(std::wstring id, bool updateCache, bool getChildren, bool ignoreError)
 {
-  // Note: lets try always refreshing folders
   Log::WriteOutput(LogType::Debug, L"FileManager::GetFile %s, updateCache=%d, getChildren=%d, ignoreError=%d", id.c_str(), updateCache, getChildren, ignoreError);
 
   // public function should all be locked
@@ -283,22 +282,6 @@ FileInfo* FileManager::GetFile(std::wstring id, bool updateCache, bool getChildr
     if (file == NULL)
     {
       file = _GetFiles(id, updateCache, getChildren, ignoreError);
-    }
-  }
-
-  if (file == NULL || file->Trashed == true) // I'm not sure why I am having to check this right now.. lets see if it fixes the issue I'm having
-  {
-    // File definitely doesn't exist
-    if (!IsRootId(id) && _ignoredIds.find(id) == _ignoredIds.end())
-    {
-      if (file != NULL)
-      {
-        file->AddRef();
-      }
-
-      _ignoredIds.insert(FileMapItem(id, file));
-
-      Log::Error(L"FileManager::GetFile() We were asked to lookup an id that we are sure doesn't exist, adding id to the ignore list");
     }
   }
 

--- a/DriveFusion/FusionGDShell.vcxproj
+++ b/DriveFusion/FusionGDShell.vcxproj
@@ -350,6 +350,7 @@ $(SolutionDir)/obj/$(Configuration)/bin/ProjectConfigGenerator.exe $(SolutionDir
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ChildItemIDPolicy.h" />
+    <ClInclude Include="ErrorSignaling.h" />
     <ClInclude Include="IdList.h" />
     <ClInclude Include="DisposableHandle.h" />
     <ClInclude Include="dllmain.h" />

--- a/DriveFusion/FusionGDShell.vcxproj.filters
+++ b/DriveFusion/FusionGDShell.vcxproj.filters
@@ -222,6 +222,9 @@
     <ClInclude Include="PropVariant.h">
       <Filter>Common Shell Files\Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ErrorSignaling.h">
+      <Filter>Common Shell Files\Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="FusionGDShell.rc">

--- a/DriveFusion/GDriveShlExt.cpp
+++ b/DriveFusion/GDriveShlExt.cpp
@@ -544,7 +544,7 @@ HRESULT CGDriveShlExt::_GetDataFromID(const std::wstring& id, bool updateCache, 
     {
       Log::WriteOutput(LogType::Error, L"Could not find file with specified id=%s", id.c_str());
     }
-    hr = E_INVALIDARG;
+    CHECK_HR(HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
   }
 
   return hr;
@@ -1301,32 +1301,23 @@ STDMETHODIMP CGDriveShlExt::GetAttributesOf(UINT cidl, __in_ecount_opt(cidl) PCU
   try
   {
     Log::WriteOutput(LogType::Debug, L"IShellFolder::GetAttributesOf(UINT cidl, __in_ecount_opt(cidl) PCUITEMID_CHILD_ARRAY rgpidl, __inout SFGAOF *rgfInOut)", cidl);
-    HRESULT hr = E_INVALIDARG;
+    HRESULT hr = S_OK;
 
-    if (cidl && rgpidl)
+    CHECK_ARG(rgpidl != nullptr);
+    CHECK_ARG(rgfInOut != nullptr);
+
+    ULONG rgfOut = *rgfInOut;
+
+    for (UINT i = 0; i < cidl; i++)
     {
-      hr = S_OK;
-
-      ULONG rgfOut = *rgfInOut;
-
-      for (UINT i = 0; i < cidl; i++)
-      {
-        DWORD rgfItem;
-
-        hr = _GetAttributesOf(rgpidl[i], *rgfInOut, &rgfItem);
-
-        if (!SUCCEEDED(hr))
-          break;
-
-        rgfOut &= rgfItem;
-      }
-
-      if (SUCCEEDED(hr))
-      {
-        *rgfInOut = rgfOut;
-      }
+      FileInfo* fileInfo = nullptr;
+      CHECK_HR(_GetDataFromIDList(rgpidl[i], false, false, &fileInfo));
+      DWORD dwMask = 0;
+      CHECK_HR(_GetAttributesOf(fileInfo, &dwMask));
+      rgfOut &= dwMask;
     }
 
+    *rgfInOut = rgfOut;
     return hr;
   }
   catch (...)
@@ -2725,6 +2716,7 @@ STDMETHODIMP CGDriveShlExt::GetDisplayNameOf(PCUITEMID_CHILD pidl, SHGDNF uFlags
   try
   {
     Log::WriteOutput(LogType::Debug, L"IShellFolder::GetDisplayNameOf(PCUITEMID_CHILD pidl, SHGDNF uFlags, __out STRRET *psrName)");
+    HRESULT hr = S_OK;
 
     static const BYTE _indices[] =
     {
@@ -2769,12 +2761,8 @@ STDMETHODIMP CGDriveShlExt::GetDisplayNameOf(PCUITEMID_CHILD pidl, SHGDNF uFlags
       index |= DISPLAYNAMEOFINFO::GDNM_FOREDITING;
     }
 
-    HRESULT hr = (this->*_DisplayNameOfInfo[_indices[index]]._GetDisplayNameOf)(pidl, uFlags, &psrName->pOleStr);
-
-    if (SUCCEEDED(hr))
-    {
-      psrName->uType = STRRET_WSTR;
-    }
+    CHECK_HR((this->*_DisplayNameOfInfo[_indices[index]]._GetDisplayNameOf)(pidl, uFlags, &psrName->pOleStr));
+    psrName->uType = STRRET_WSTR;
 
     return hr;
   }

--- a/DriveFusion/GDriveShlExt.cpp
+++ b/DriveFusion/GDriveShlExt.cpp
@@ -538,7 +538,7 @@ HRESULT CGDriveShlExt::_GetDataFromID(const std::wstring& id, bool updateCache, 
   {
     if (_fileManager.HasError())
     {
-      Log::WriteOutput(LogType::Error, L"Could not find file with specified id=%s - %s", id.c_str(), _fileManager.ErrorMessage().c_str(), _fileManager.ErrorMessage());
+      Log::WriteOutput(LogType::Error, L"Could not find file with specified id=%s - %s", id.c_str(), _fileManager.ErrorMessage().c_str());
     }
     else
     {

--- a/DriveFusion/stdafx.h
+++ b/DriveFusion/stdafx.h
@@ -63,6 +63,7 @@ limitations under the License.
 #include "PropVariant.h"
 #include "IDList.h"
 #include "PathInfo.h"
+#include "ErrorSignaling.h"
 #include "FileManager.h"
 
 #define IDI_ROOT            100


### PR DESCRIPTION
Fixes google/google-drive-shell-extension#12

Added three macros to check constraints and homogenize error signaling.

Removed a block that was adding newly created files to the ignoredIds map and preventing the explorer view from showing the new file.

Corrected an error return in _GetDataFromID from invalid argument to file not found.

Simplified the code for GetAttributesOf.
